### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/report-issue/index.ts
+++ b/supabase/functions/report-issue/index.ts
@@ -183,7 +183,7 @@ serve(async (req) => {
     return json(
       {
         error: 'Failed to contact GitHub.',
-        details: error instanceof Error ? error.message : String(error),
+        details: 'An unexpected error occurred while contacting GitHub.',
       },
       502,
     );


### PR DESCRIPTION
Potential fix for [https://github.com/YauheniX/family-logistics-dashboard/security/code-scanning/5](https://github.com/YauheniX/family-logistics-dashboard/security/code-scanning/5)

In general, to fix this problem you should avoid sending raw exception information (messages, stacks, or stringified `Error` objects) back to the client. Instead, log the detailed error information on the server (for debugging/monitoring), and return only a generic, user-friendly message or a coarse-grained error code to the client.

For this file, the minimal and safest change that preserves existing behavior is:

- Keep the server-side logging in the `catch (error)` at lines 181–182.
- Stop including the raw `error` (or its `.message`) in the HTTP response body.
- Replace the `details` field in the JSON response with a generic string that does not depend on `error`, or remove `details` entirely.

Concretely:

- In `supabase/functions/report-issue/index.ts`, in the `catch (error)` block around lines 181–189, change the `json` call so that `details` is either removed or set to a constant generic message, e.g. `"An unexpected error occurred while contacting GitHub."`.
- The `json` helper function itself (lines 193–201) can stay as-is; the issue is what we pass as `payload`.

No additional imports or new helper methods are required; we only adjust the response payload in the catch block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
