### PR TITLE
Update Supabase CLI version to latest in workflows

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -99,7 +99,7 @@ jobs:
         if: steps.detect-changes.outputs.has_changes == 'true'
         uses: supabase/setup-cli@v1
         with:
-          version: 1.178.2
+          version: latest
 
       - name: Apply migrations to Supabase (Production)
         if: steps.detect-changes.outputs.has_changes == 'true'
@@ -180,7 +180,7 @@ jobs:
         if: steps.detect-changes-staging.outputs.has_changes == 'true'
         uses: supabase/setup-cli@v1
         with:
-          version: 1.178.2
+          version: latest
 
       - name: Apply to staging
         if: steps.detect-changes-staging.outputs.has_changes == 'true'


### PR DESCRIPTION
Ensures GitHub workflows always use the most recent Supabase CLI, reducing maintenance and enabling immediate access to new features and bug fixes.