### PR TITLE
feat: add lucide-vue-next icons and replace existing SVGs

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -57,16 +57,13 @@ test.describe('Login flow', () => {
   test('signs in with existing credentials and lands on dashboard', async ({ page }) => {
     // Pre-seed a known user WITHOUT a currentUser so the app starts as logged-out
     // but the user account already "exists" in the mock auth store.
-    await page.addInitScript(
-      ({ key, value }) => localStorage.setItem(key, value),
-      {
-        key: lsKey('auth-data'),
-        value: JSON.stringify({
-          users: [{ id: 'preset-user-1', email: 'preset@example.com', password: 'password123' }],
-          currentUser: null,
-        }),
-      },
-    );
+    await page.addInitScript(({ key, value }) => localStorage.setItem(key, value), {
+      key: lsKey('auth-data'),
+      value: JSON.stringify({
+        users: [{ id: 'preset-user-1', email: 'preset@example.com', password: 'password123' }],
+        currentUser: null,
+      }),
+    });
 
     await page.goto('/login');
 
@@ -103,9 +100,7 @@ test.describe('Household selection', () => {
       timeout: 8_000,
     });
     // "Create Household" action button should be visible
-    await expect(
-      page.getByRole('button', { name: /create household/i }),
-    ).toBeVisible();
+    await expect(page.getByRole('button', { name: /create household/i })).toBeVisible();
     // The seeded household name should appear somewhere on the page
     // (in the sidebar, header selector, or the household list itself)
     await expect(page.getByText('Smith Family').first()).toBeAttached({ timeout: 8_000 });
@@ -187,7 +182,10 @@ test.describe('Shopping list – create and edit', () => {
     // Fill in item name in the modal
     const itemInput = page.getByPlaceholder(/item name/i);
     await itemInput.fill('Milk');
-    await page.getByRole('button', { name: /add item/i }).last().click();
+    await page
+      .getByRole('button', { name: /add item/i })
+      .last()
+      .click();
 
     // Item should appear in the list
     await expect(page.getByText('Milk')).toBeVisible({ timeout: 8_000 });
@@ -209,11 +207,17 @@ test.describe('Shopping list – create and edit', () => {
     await page.getByRole('button', { name: /edit/i }).first().click();
     await page.getByRole('button', { name: /add item/i }).click();
     await page.getByPlaceholder(/item name/i).fill('Eggs');
-    await page.getByRole('button', { name: /add item/i }).last().click();
+    await page
+      .getByRole('button', { name: /add item/i })
+      .last()
+      .click();
     await expect(page.getByText('Eggs')).toBeVisible({ timeout: 8_000 });
 
     // Switch to Shopping mode and toggle the item
-    await page.getByRole('button', { name: /shopping/i }).first().click();
+    await page
+      .getByRole('button', { name: /shopping/i })
+      .first()
+      .click();
     // Find the checkbox associated with the "Eggs" label (not the filter checkboxes)
     const itemCheckbox = page.getByLabel('Eggs');
     await itemCheckbox.check();
@@ -259,7 +263,9 @@ test.describe('Public wishlist – share and reserve', () => {
     await page.getByRole('button', { name: /reserve this/i }).click();
 
     // The reservation modal should open — identified by its title heading
-    await expect(page.getByRole('heading', { name: 'Reserve Item' })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('heading', { name: 'Reserve Item' })).toBeVisible({
+      timeout: 5_000,
+    });
     await expect(page.getByLabel('Your Name')).toBeVisible();
     await expect(page.getByLabel('Your Email')).toBeVisible();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.45.0",
         "chart.js": "^4.4.7",
+        "lucide-vue-next": "^0.577.0",
         "pinia": "^2.1.7",
         "supabase": "^2.76.12",
         "vue": "^3.4.21",
@@ -284,6 +285,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -324,6 +326,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1662,6 +1665,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2093,6 +2097,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.28.tgz",
       "integrity": "sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@vue/compiler-core": "3.5.28",
@@ -2234,6 +2239,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2592,6 +2598,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2729,6 +2736,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3316,6 +3324,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3372,6 +3381,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4616,6 +4626,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4981,6 +4992,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.577.0.tgz",
+      "integrity": "sha512-py05bAfv9SHVJqscbiOnjcnLlEmOffA58a+7XhZuFxrs6txe1E8VoR1ngWGTYO+9aVKABAz8l3ee3PqiQN9QPA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/lz-string": {
@@ -5746,6 +5766,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5905,6 +5926,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6826,6 +6848,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6970,6 +6993,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7058,6 +7082,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7151,6 +7176,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7164,6 +7190,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7261,6 +7288,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",
     "chart.js": "^4.4.7",
+    "lucide-vue-next": "^0.577.0",
     "pinia": "^2.1.7",
     "supabase": "^2.76.12",
     "vue": "^3.4.21",

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,20 +33,7 @@
               class="hidden sm:inline-flex hover:shadow-soft"
               @click="reportModalOpen = true"
             >
-              <svg
-                class="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
-                />
-              </svg>
+              <Flag class="h-5 w-5" aria-hidden="true" />
             </BaseButton>
             <div class="hidden sm:block">
               <ThemeToggle />
@@ -104,6 +91,7 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted } from 'vue';
 import { RouterView, RouterLink, useRoute, useRouter } from 'vue-router';
+import { Flag } from 'lucide-vue-next';
 import SidebarNav from '@/components/layout/SidebarNav.vue';
 import BottomNav from '@/components/layout/BottomNav.vue';
 import Breadcrumbs from '@/components/layout/Breadcrumbs.vue';

--- a/src/__tests__/avatar.test.ts
+++ b/src/__tests__/avatar.test.ts
@@ -217,7 +217,7 @@ describe('Avatar', () => {
         },
       });
 
-      expect(wrapper.text()).toContain('👑');
+      expect(wrapper.find('span[title="Owner"] svg').exists()).toBe(true);
       expect(wrapper.html()).toContain('Owner');
     });
 
@@ -230,19 +230,19 @@ describe('Avatar', () => {
         },
       });
 
-      expect(wrapper.text()).not.toContain('👑');
+      expect(wrapper.find('span[title="Owner"] svg').exists()).toBe(false);
     });
 
     it('renders correct icon for each role', () => {
       const roles = [
-        { role: 'owner', icon: '👑' },
-        { role: 'admin', icon: '⭐' },
-        { role: 'member', icon: '👤' },
-        { role: 'child', icon: '👶' },
-        { role: 'viewer', icon: '👀' },
+        { role: 'owner', label: 'Owner' },
+        { role: 'admin', label: 'Admin' },
+        { role: 'member', label: 'Member' },
+        { role: 'child', label: 'Child' },
+        { role: 'viewer', label: 'Viewer' },
       ];
 
-      roles.forEach(({ role, icon }) => {
+      roles.forEach(({ role, label }) => {
         const wrapper = mount(Avatar, {
           props: {
             name: 'Test User',
@@ -250,7 +250,7 @@ describe('Avatar', () => {
           },
         });
 
-        expect(wrapper.text()).toContain(icon);
+        expect(wrapper.find(`span[title="${label}"] svg`).exists()).toBe(true);
       });
     });
 
@@ -390,7 +390,6 @@ describe('Avatar', () => {
         // badgeIconSize should be ~25% of container
         expect(badgeStyle).toMatch(/width:\s*\d+(\.\d+)?px/);
         expect(badgeStyle).toMatch(/height:\s*\d+(\.\d+)?px/);
-        expect(badgeStyle).toMatch(/font-size:\s*\d+(\.\d+)?px/);
       }
     });
 
@@ -511,7 +510,7 @@ describe('Avatar', () => {
         },
       });
 
-      expect(wrapper.text()).toContain('👤');
+      expect(wrapper.find('span[title="Member"] svg').exists()).toBe(true);
     });
 
     it('uses default size of 64', () => {

--- a/src/components/layout/BottomNav.vue
+++ b/src/components/layout/BottomNav.vue
@@ -26,12 +26,12 @@
         "
         :aria-label="item.label"
       >
-        <span
-          class="text-xl transition-transform"
+        <component
+          :is="item.icon"
+          class="w-5 h-5 transition-transform"
           :class="isActive(item.name) ? 'scale-110' : ''"
           aria-hidden="true"
-          >{{ item.emoji }}</span
-        >
+        />
         <span class="text-[10px] sm:text-xs font-medium truncate max-w-[70px] sm:max-w-[80px]">{{
           item.label
         }}</span>
@@ -49,12 +49,11 @@
         aria-label="More options"
         @click="toggleMoreMenu"
       >
-        <span
-          class="text-xl transition-transform"
+        <MoreHorizontal
+          class="w-5 h-5 transition-transform"
           :class="showMoreMenu ? 'rotate-90' : ''"
           aria-hidden="true"
-          >⋯</span
-        >
+        />
         <span class="text-[10px] sm:text-xs font-medium">{{ $t('nav.more') }}</span>
       </button>
     </div>
@@ -85,9 +84,11 @@
             "
             @click="closeMoreMenu"
           >
-            <span class="text-lg transition-transform hover:scale-110" aria-hidden="true">{{
-              item.emoji
-            }}</span>
+            <component
+              :is="item.icon"
+              class="w-5 h-5 transition-transform hover:scale-110"
+              aria-hidden="true"
+            />
             <span class="text-sm font-medium">{{ item.label }}</span>
           </RouterLink>
         </div>
@@ -98,8 +99,19 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
+import type { Component } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+import {
+  Home,
+  ShoppingCart,
+  Gift,
+  Building2,
+  School,
+  LayoutGrid,
+  Settings,
+  MoreHorizontal,
+} from 'lucide-vue-next';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -109,22 +121,22 @@ interface NavItem {
   name: string;
   label: string;
   to: string | { name: string };
-  emoji: string;
+  icon: Component;
 }
 
 // Primary navigation items (always visible)
 const navItems = computed<NavItem[]>(() => [
-  { name: 'dashboard', label: t('nav.home'), to: { name: 'dashboard' }, emoji: '🏠' },
-  { name: 'shopping', label: t('nav.shopping'), to: { name: 'shopping' }, emoji: '🛒' },
-  { name: 'wishlist-list', label: t('nav.wishlists'), to: '/wishlists', emoji: '🎁' },
+  { name: 'dashboard', label: t('nav.home'), to: { name: 'dashboard' }, icon: Home },
+  { name: 'shopping', label: t('nav.shopping'), to: { name: 'shopping' }, icon: ShoppingCart },
+  { name: 'wishlist-list', label: t('nav.wishlists'), to: '/wishlists', icon: Gift },
 ]);
 
 // Additional items in "More" menu
 const moreItems = computed<NavItem[]>(() => [
-  { name: 'household-list', label: t('nav.households'), to: '/households', emoji: '🏠' },
-  { name: 'school', label: t('nav.school'), to: '/school', emoji: '🏫' },
-  { name: 'apps', label: t('nav.apps'), to: '/apps', emoji: '📱' },
-  { name: 'settings', label: t('nav.settings'), to: '/settings', emoji: '⚙️' },
+  { name: 'household-list', label: t('nav.households'), to: '/households', icon: Building2 },
+  { name: 'school', label: t('nav.school'), to: '/school', icon: School },
+  { name: 'apps', label: t('nav.apps'), to: '/apps', icon: LayoutGrid },
+  { name: 'settings', label: t('nav.settings'), to: '/settings', icon: Settings },
 ]);
 
 function isActive(routeName: string): boolean {

--- a/src/components/layout/Breadcrumbs.vue
+++ b/src/components/layout/Breadcrumbs.vue
@@ -21,16 +21,11 @@
       >
         {{ crumb.label }}
       </span>
-      <svg
+      <ChevronRight
         v-if="index < breadcrumbs.length - 1"
         class="h-4 w-4 text-neutral-400 dark:text-neutral-500"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
         aria-hidden="true"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-      </svg>
+      />
     </RouterLink>
   </nav>
 </template>
@@ -38,6 +33,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
+import { ChevronRight } from 'lucide-vue-next';
 import { useShoppingStore } from '@/features/shopping/presentation/shopping.store';
 import { useHouseholdStore } from '@/stores/household';
 

--- a/src/components/layout/HouseholdSwitcher.vue
+++ b/src/components/layout/HouseholdSwitcher.vue
@@ -10,15 +10,7 @@
       <span class="md:inline max-w-[100px] truncate">
         {{ currentHousehold?.name || 'Select Household' }}
       </span>
-      <svg
-        class="h-6 w-6 transition-transform"
-        :class="{ 'rotate-180': isOpen }"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-      </svg>
+      <ChevronDown class="h-6 w-6 transition-transform" :class="{ 'rotate-180': isOpen }" />
     </button>
 
     <!-- Dropdown Menu -->
@@ -49,18 +41,10 @@
               {{ household.role }}
             </p>
           </div>
-          <svg
+          <Check
             v-if="household.id === currentHousehold?.id"
             class="h-5 w-5 text-primary-600 dark:text-primary-400"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
+          />
         </button>
       </div>
 
@@ -110,6 +94,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ChevronDown, Check } from 'lucide-vue-next';
 import { useHouseholdStore } from '@/stores/household';
 import { useToastStore } from '@/stores/toast';
 import ModalDialog from '@/components/shared/ModalDialog.vue';

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -14,8 +14,8 @@
     <!-- Logo/Brand -->
     <div class="mb-6">
       <div class="flex items-center gap-2 mb-1">
-        <span class="text-2xl" aria-hidden="true">🏡</span>
-        <h2 class="text-xl font-bold text-neutral-900 dark:text-neutral-50">
+        <Home class="w-6 h-6 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+        <h2 class="text-xl font-bold font-display text-neutral-900 dark:text-neutral-50">
           {{ $t('nav.brandName') }}
         </h2>
       </div>
@@ -30,9 +30,10 @@
       class="mb-6 rounded-xl bg-gradient-to-br from-primary-50 to-primary-100 dark:from-primary-900/40 dark:to-primary-800/40 p-4 border border-primary-200 dark:border-primary-700 shadow-soft hover:shadow-medium transition-shadow duration-normal"
     >
       <div class="flex items-center gap-2 mb-1">
-        <span class="text-xl animate-bounce-subtle" aria-hidden="true">{{
-          currentHousehold.emoji || '🏠'
-        }}</span>
+        <Home
+          class="w-5 h-5 text-primary-600 dark:text-primary-400 animate-bounce-subtle"
+          aria-hidden="true"
+        />
         <p class="font-semibold text-neutral-900 dark:text-neutral-50 truncate">
           {{ currentHousehold.name }}
         </p>
@@ -56,9 +57,11 @@
         "
         @click="emit('close')"
       >
-        <span class="text-lg transition-transform group-hover:scale-110" aria-hidden="true">{{
-          item.emoji
-        }}</span>
+        <component
+          :is="item.icon"
+          class="w-5 h-5 transition-transform group-hover:scale-110"
+          aria-hidden="true"
+        />
         <span>{{ item.label }}</span>
       </RouterLink>
     </nav>
@@ -70,8 +73,8 @@
     <!-- Logo/Brand -->
     <div class="mb-6">
       <div class="flex items-center gap-2 mb-1">
-        <span class="text-2xl" aria-hidden="true">🏡</span>
-        <h2 class="text-xl font-bold text-neutral-900 dark:text-neutral-50">
+        <Home class="w-6 h-6 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+        <h2 class="text-xl font-bold font-display text-neutral-900 dark:text-neutral-50">
           {{ $t('nav.brandName') }}
         </h2>
       </div>
@@ -86,9 +89,10 @@
       class="mb-6 rounded-xl bg-gradient-to-br from-primary-50 to-primary-100 dark:from-primary-900/40 dark:to-primary-800/40 p-4 border border-primary-200 dark:border-primary-700 shadow-soft hover:shadow-medium transition-shadow duration-normal"
     >
       <div class="flex items-center gap-2 mb-1">
-        <span class="text-xl animate-bounce-subtle" aria-hidden="true">{{
-          currentHousehold.emoji || '🏠'
-        }}</span>
+        <Home
+          class="w-5 h-5 text-primary-600 dark:text-primary-400 animate-bounce-subtle"
+          aria-hidden="true"
+        />
         <p class="font-semibold text-neutral-900 dark:text-neutral-50 truncate">
           {{ currentHousehold.name }}
         </p>
@@ -111,9 +115,11 @@
             : 'text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:shadow-soft hover:translate-x-1'
         "
       >
-        <span class="text-lg transition-transform group-hover:scale-110" aria-hidden="true">{{
-          item.emoji
-        }}</span>
+        <component
+          :is="item.icon"
+          class="w-5 h-5 transition-transform group-hover:scale-110"
+          aria-hidden="true"
+        />
         <span>{{ item.label }}</span>
       </RouterLink>
     </nav>
@@ -122,8 +128,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import type { Component } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+import { Home, Building2, ShoppingCart, Gift, School, LayoutGrid, Settings } from 'lucide-vue-next';
 import { useHouseholdStore } from '@/stores/household';
 
 withDefaults(
@@ -157,12 +165,17 @@ const items = computed(() => [
     name: 'household-list',
     label: t('nav.households'),
     to: '/households',
-    emoji: '🏘️',
+    icon: Building2 as Component,
   },
-  { name: 'shopping', label: t('nav.shopping'), to: { name: 'shopping' }, emoji: '🛒' },
-  { name: 'wishlist-list', label: t('nav.wishlists'), to: '/wishlists', emoji: '🎁' },
-  { name: 'school', label: t('nav.school'), to: '/school', emoji: '🏫' },
-  { name: 'apps', label: t('nav.apps'), to: '/apps', emoji: '🎮' },
-  { name: 'settings', label: t('nav.settings'), to: '/settings', emoji: '⚙️' },
+  {
+    name: 'shopping',
+    label: t('nav.shopping'),
+    to: { name: 'shopping' },
+    icon: ShoppingCart as Component,
+  },
+  { name: 'wishlist-list', label: t('nav.wishlists'), to: '/wishlists', icon: Gift as Component },
+  { name: 'school', label: t('nav.school'), to: '/school', icon: School as Component },
+  { name: 'apps', label: t('nav.apps'), to: '/apps', icon: LayoutGrid as Component },
+  { name: 'settings', label: t('nav.settings'), to: '/settings', icon: Settings as Component },
 ]);
 </script>

--- a/src/components/members/MemberCard.vue
+++ b/src/components/members/MemberCard.vue
@@ -86,14 +86,7 @@
           class="p-2 text-neutral-500 hover:text-primary-600 dark:text-neutral-400 dark:hover:text-primary-400 transition-all duration-200 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg hover:scale-110 focus-ring"
           @click="$emit('edit', member)"
         >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-            />
-          </svg>
+          <SquarePen class="w-5 h-5" />
         </button>
         <button
           v-if="canRemove"
@@ -102,14 +95,7 @@
           class="p-2 text-neutral-500 hover:text-danger-600 dark:text-neutral-400 dark:hover:text-danger-400 transition-all duration-200 hover:bg-danger-50 dark:hover:bg-danger-900/20 rounded-lg hover:scale-110 focus-ring"
           @click="$emit('remove', member.id)"
         >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-            />
-          </svg>
+          <Trash2 class="w-5 h-5" />
         </button>
       </div>
     </div>
@@ -118,6 +104,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { SquarePen, Trash2 } from 'lucide-vue-next';
 import Avatar from '@/components/shared/Avatar.vue';
 import BaseBadge from '@/components/shared/BaseBadge.vue';
 import { getRoleLabel } from '@/utils/roleUtils';

--- a/src/components/shared/Avatar.vue
+++ b/src/components/shared/Avatar.vue
@@ -46,10 +46,14 @@
       <span
         class="inline-flex items-center justify-center rounded-full border-2 border-white dark:border-neutral-800 transition-all"
         :class="roleIconClass"
-        :style="{ width: badgeSize, height: badgeSize, fontSize: badgeIconSize }"
+        :style="{ width: badgeSize, height: badgeSize }"
         :title="roleLabel"
       >
-        {{ roleIcon }}
+        <component
+          :is="roleIcon"
+          class="text-white"
+          :style="{ width: badgeIconSize, height: badgeIconSize }"
+        />
       </span>
     </div>
   </div>

--- a/src/components/shared/BaseInput.vue
+++ b/src/components/shared/BaseInput.vue
@@ -73,13 +73,7 @@
         class="absolute right-3 top-1/2 -translate-y-1/2 text-success-500 dark:text-success-400 animate-check-in"
         aria-hidden="true"
       >
-        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-          <path
-            fill-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clip-rule="evenodd"
-          />
-        </svg>
+        <Check class="w-5 h-5" />
       </span>
 
       <!-- Password Toggle -->
@@ -91,35 +85,11 @@
         :aria-label="showPassword ? 'Hide password' : 'Show password'"
         @click="togglePasswordVisibility"
       >
-        <svg
+        <component
+          :is="showPassword ? EyeOff : Eye"
           class="w-5 h-5 transition-transform duration-200"
           :class="{ 'rotate-180': showPassword }"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            v-if="!showPassword"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-          />
-          <path
-            v-if="!showPassword"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-          />
-          <path
-            v-else
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-          />
-        </svg>
+        />
       </button>
 
       <!-- Icon Right -->
@@ -158,13 +128,7 @@
       :id="`${inputId}-error`"
       class="text-sm text-danger-500 dark:text-danger-400 flex items-center gap-1 animate-slide-down"
     >
-      <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-        <path
-          fill-rule="evenodd"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-          clip-rule="evenodd"
-        />
-      </svg>
+      <CircleX class="w-4 h-4" aria-hidden="true" />
       {{ error }}
     </p>
     <!-- Hint Message -->
@@ -176,6 +140,7 @@
 
 <script setup lang="ts">
 import { computed, ref, useSlots } from 'vue';
+import { Check, Eye, EyeOff, CircleX } from 'lucide-vue-next';
 
 const slots = useSlots();
 

--- a/src/components/shared/EmptyState.vue
+++ b/src/components/shared/EmptyState.vue
@@ -42,19 +42,7 @@
     >
       <span class="relative z-10 flex items-center gap-2">
         {{ cta }}
-        <svg
-          class="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M13 7l5 5m0 0l-5 5m5-5H6"
-          />
-        </svg>
+        <ArrowRight class="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1" />
       </span>
       <!-- Ripple effect background -->
       <span
@@ -78,6 +66,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import { ArrowRight } from 'lucide-vue-next';
 
 withDefaults(
   defineProps<{

--- a/src/components/shared/FormProgress.vue
+++ b/src/components/shared/FormProgress.vue
@@ -17,18 +17,7 @@
     >
       <div class="progress-step-circle">
         <!-- Completed Step -->
-        <svg
-          v-if="step < currentStep"
-          class="w-5 h-5 text-white animate-check-in"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clip-rule="evenodd"
-          />
-        </svg>
+        <Check v-if="step < currentStep" class="w-5 h-5 text-white animate-check-in" />
         <!-- Active/Future Step -->
         <span v-else class="text-sm font-semibold">{{ step }}</span>
       </div>
@@ -47,6 +36,8 @@
 </template>
 
 <script setup lang="ts">
+import { Check } from 'lucide-vue-next';
+
 interface Props {
   currentStep: number;
   totalSteps: number;

--- a/src/components/shared/LinkPreview.vue
+++ b/src/components/shared/LinkPreview.vue
@@ -19,20 +19,7 @@
           class="w-full h-full object-cover"
           @error="handleImageError"
         />
-        <svg
-          v-else
-          class="h-24 w-24 text-neutral-400 dark:text-neutral-500"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-          />
-        </svg>
+        <Link v-else class="h-24 w-24 text-neutral-400 dark:text-neutral-500" />
       </div>
 
       <!-- Content -->
@@ -54,14 +41,7 @@
 
         <!-- Domain -->
         <p class="text-xs text-neutral-500 dark:text-neutral-500 flex items-center gap-1">
-          <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-            />
-          </svg>
+          <Globe class="h-3 w-3" />
           {{ preview?.domain || extractDomain(url) || url }}
         </p>
       </div>
@@ -71,6 +51,7 @@
 
 <script setup lang="ts">
 import { ref, watch, onMounted, onBeforeUnmount, computed } from 'vue';
+import { Link, Globe } from 'lucide-vue-next';
 import { isValidUrl } from '@/utils/validation';
 import {
   type LinkPreviewData,

--- a/src/components/shared/ModalDialog.vue
+++ b/src/components/shared/ModalDialog.vue
@@ -22,14 +22,7 @@
               aria-label="Close modal"
               @click="$emit('close')"
             >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X class="w-5 h-5" />
             </button>
           </div>
           <div class="modal-content px-6 pb-6 pt-4 overflow-y-auto flex-1">
@@ -42,6 +35,8 @@
 </template>
 
 <script setup lang="ts">
+import { X } from 'lucide-vue-next';
+
 defineProps<{
   open: boolean;
   title: string;

--- a/src/components/shared/SkeletonLoader.vue
+++ b/src/components/shared/SkeletonLoader.vue
@@ -44,17 +44,7 @@
       class="skeleton-image animate-pulse"
       :style="{ aspectRatio: aspectRatio }"
     >
-      <svg
-        class="mx-auto my-auto w-12 h-12 text-neutral-300 dark:text-neutral-600"
-        fill="currentColor"
-        viewBox="0 0 20 20"
-      >
-        <path
-          fill-rule="evenodd"
-          d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"
-          clip-rule="evenodd"
-        />
-      </svg>
+      <ImageIcon class="mx-auto my-auto w-12 h-12 text-neutral-300 dark:text-neutral-600" />
     </div>
 
     <!-- Wishlist/Shopping Grid Skeleton -->
@@ -89,6 +79,8 @@
 </template>
 
 <script setup lang="ts">
+import { Image as ImageIcon } from 'lucide-vue-next';
+
 interface Props {
   variant?:
     | 'card'

--- a/src/components/shared/ThemeToggle.vue
+++ b/src/components/shared/ThemeToggle.vue
@@ -6,46 +6,25 @@
     @click="toggleTheme"
   >
     <Transition name="theme-icon" mode="out-in">
-      <svg
+      <Sun
         v-if="currentTheme === 'dark'"
         key="sun"
-        xmlns="http://www.w3.org/2000/svg"
         class="h-5 w-5 transition-transform group-hover:rotate-90 duration-slow"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
         aria-hidden="true"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-        />
-      </svg>
-      <svg
+      />
+      <Moon
         v-else
         key="moon"
-        xmlns="http://www.w3.org/2000/svg"
         class="h-5 w-5 transition-transform group-hover:-rotate-12 duration-slow"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
         aria-hidden="true"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-        />
-      </svg>
+      />
     </Transition>
   </button>
 </template>
 
 <script setup lang="ts">
 import { useTheme } from '@/composables/useTheme';
+import { Sun, Moon } from 'lucide-vue-next';
 
 const { currentTheme, toggleTheme } = useTheme();
 </script>

--- a/src/components/shared/ToastContainer.vue
+++ b/src/components/shared/ToastContainer.vue
@@ -11,7 +11,7 @@
         :class="toastClasses(toast.type)"
         class="flex items-center gap-3 rounded-lg px-4 py-3 shadow-lg w-full"
       >
-        <span class="text-lg">{{ toastIcon(toast.type) }}</span>
+        <component :is="toastIcon(toast.type)" class="w-5 h-5 flex-shrink-0" />
         <p class="flex-1 text-sm font-medium">{{ toast.message }}</p>
         <button
           type="button"
@@ -27,6 +27,8 @@
 
 <script setup lang="ts">
 import { useToastStore } from '@/stores/toast';
+import { CheckCircle, CircleX, AlertTriangle, Info } from 'lucide-vue-next';
+import type { Component } from 'vue';
 import type { ToastType } from '@/types/api';
 
 const toastStore = useToastStore();
@@ -44,12 +46,12 @@ const toastClasses = (type: ToastType) => {
   return classes[type] || classes.info;
 };
 
-const toastIcon = (type: ToastType) => {
-  const icons = {
-    success: '✓',
-    error: '✕',
-    warning: '⚠',
-    info: 'ℹ',
+const toastIcon = (type: ToastType): Component => {
+  const icons: Record<ToastType, Component> = {
+    success: CheckCircle,
+    error: CircleX,
+    warning: AlertTriangle,
+    info: Info,
   };
   return icons[type] || icons.info;
 };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=Turret+Road:wght@400;500;700;800&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -18,6 +18,7 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family:
+    'Turret Road',
     'Inter',
     'Poppins',
     system-ui,

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -6,6 +6,8 @@
  */
 
 import type { MemberRole } from '@/features/shared/domain/entities';
+import type { Component } from 'vue';
+import { Crown, Star, User, Baby, Eye } from 'lucide-vue-next';
 
 export const ROLE_LABELS: Record<MemberRole, string> = {
   owner: 'Owner',
@@ -15,12 +17,12 @@ export const ROLE_LABELS: Record<MemberRole, string> = {
   viewer: 'Viewer',
 };
 
-export const ROLE_ICONS: Record<MemberRole, string> = {
-  owner: '👑',
-  admin: '⭐',
-  member: '👤',
-  child: '👶',
-  viewer: '👀',
+export const ROLE_ICONS: Record<MemberRole, Component> = {
+  owner: Crown,
+  admin: Star,
+  member: User,
+  child: Baby,
+  viewer: Eye,
 };
 
 export const ROLE_STYLES = {
@@ -48,10 +50,10 @@ export function getRoleLabel(role: string): string {
 }
 
 /**
- * Get the emoji icon for a role
+ * Get the icon component for a role
  */
-export function getRoleIcon(role: string): string {
-  return ROLE_ICONS[role as MemberRole] || '👤';
+export function getRoleIcon(role: string): Component {
+  return ROLE_ICONS[role as MemberRole] || User;
 }
 
 /**

--- a/src/views/HouseholdDetailView.vue
+++ b/src/views/HouseholdDetailView.vue
@@ -16,14 +16,7 @@
               aria-label="Rename household"
               @click="openRenameModal"
             >
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                />
-              </svg>
+              <Pencil class="h-4 w-4" />
             </button>
           </div>
         </div>
@@ -155,6 +148,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
+import { Pencil } from 'lucide-vue-next';
 import BaseButton from '@/components/shared/BaseButton.vue';
 import BaseCard from '@/components/shared/BaseCard.vue';
 import BaseBadge from '@/components/shared/BaseBadge.vue';

--- a/src/views/NavigationDemoView.vue
+++ b/src/views/NavigationDemoView.vue
@@ -82,14 +82,7 @@
               >
                 <span class="text-lg" aria-hidden="true">🏠</span>
                 <span class="max-w-[150px] truncate">Smith Family</span>
-                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
+                <ChevronDown class="h-4 w-4" />
               </button>
             </div>
 
@@ -266,5 +259,6 @@
 </template>
 
 <script setup lang="ts">
+import { ChevronDown } from 'lucide-vue-next';
 // Demo view - no logic needed
 </script>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -27,26 +27,7 @@
           />
           <div>
             <BaseButton variant="secondary" @click="handleAvatarUpload">
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
+              <Camera class="h-4 w-4" aria-hidden="true" />
               {{ $t('settings.profile.changePhoto') }}
             </BaseButton>
             <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
@@ -71,20 +52,7 @@
               :aria-label="$t('settings.profile.editName')"
               @click="openEditNameModal"
             >
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                />
-              </svg>
+              <Pencil class="h-4 w-4" aria-hidden="true" />
             </BaseButton>
           </div>
         </div>
@@ -195,6 +163,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { Camera, Pencil } from 'lucide-vue-next';
 import BaseCard from '@/components/shared/BaseCard.vue';
 import BaseInput from '@/components/shared/BaseInput.vue';
 import BaseButton from '@/components/shared/BaseButton.vue';

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,7 +9,8 @@ module.exports = {
         xs: '475px',
       },
       fontFamily: {
-        sans: ['Inter', 'Poppins', ...defaultTheme.fontFamily.sans],
+        sans: ['Turret Road', 'Inter', 'Poppins', ...defaultTheme.fontFamily.sans],
+        display: ['Turret Road', 'Inter', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         // Primary colors


### PR DESCRIPTION
- Added `lucide-vue-next` as a dependency.
- Replaced various SVG icons in components with corresponding icons from `lucide-vue-next` for consistency and improved maintainability.
- Updated `Avatar`, `Breadcrumbs`, `HouseholdSwitcher`, `MemberCard`, `BaseInput`, `EmptyState`, `FormProgress`, `LinkPreview`, `ModalDialog`, `SkeletonLoader`, `ThemeToggle`, `ToastContainer`, and views to use new icon components.
- Adjusted role icons in `roleUtils` to utilize `lucide-vue-next` icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated lucide-vue-next icon library for consistent, scalable icon rendering across the application, replacing emoji and inline SVG icons.

* **Style**
  * Added Turret Road font to typography system for enhanced visual design.
  * Refactored code formatting in end-to-end tests for improved readability.

* **Tests**
  * Updated role badge test assertions to verify icon component rendering.

* **Chores**
  * Added lucide-vue-next dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->